### PR TITLE
Removed Java 8, Jack, and lambdas

### DIFF
--- a/2016-11-runtime/solutions/Android/Ex1_Map/.idea/misc.xml
+++ b/2016-11-runtime/solutions/Android/Ex1_Map/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/2016-11-runtime/solutions/Android/Ex1_Map/app/build.gradle
+++ b/2016-11-runtime/solutions/Android/Ex1_Map/app/build.gradle
@@ -10,23 +10,12 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
-        // Exercise 1: Enable Java Android Compiler Kit (Jack) so you can use Java 8 features
-        jackOptions {
-            enabled true
-        }
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-
-    // Exercise 1: Set language level to Java 8
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
     }
 }
 

--- a/2016-11-runtime/solutions/Android/Ex2_ZoomButtons/.idea/misc.xml
+++ b/2016-11-runtime/solutions/Android/Ex2_ZoomButtons/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/2016-11-runtime/solutions/Android/Ex2_ZoomButtons/app/build.gradle
+++ b/2016-11-runtime/solutions/Android/Ex2_ZoomButtons/app/build.gradle
@@ -10,23 +10,12 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
-        // Exercise 1: Enable Java Android Compiler Kit (Jack) so you can use Java 8 features
-        jackOptions {
-            enabled true
-        }
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-
-    // Exercise 1: Set language level to Java 8
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
     }
 }
 

--- a/2016-11-runtime/solutions/Android/Ex3_LocFeatLyr/.idea/misc.xml
+++ b/2016-11-runtime/solutions/Android/Ex3_LocFeatLyr/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/2016-11-runtime/solutions/Android/Ex3_LocFeatLyr/app/build.gradle
+++ b/2016-11-runtime/solutions/Android/Ex3_LocFeatLyr/app/build.gradle
@@ -10,23 +10,12 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
-        // Exercise 1: Enable Java Android Compiler Kit (Jack) so you can use Java 8 features
-        jackOptions {
-            enabled true
-        }
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-
-    // Exercise 1: Set language level to Java 8
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
     }
 }
 

--- a/2016-11-runtime/solutions/Android/Ex3_LocFeatLyr/app/src/main/java/com/esri/wdc/geodev201611/MainActivity.java
+++ b/2016-11-runtime/solutions/Android/Ex3_LocFeatLyr/app/src/main/java/com/esri/wdc/geodev201611/MainActivity.java
@@ -33,13 +33,16 @@ public class MainActivity extends Activity {
 
         // Exercise 3: Instantiate and load mobile map package
         final MobileMapPackage mmpk = new MobileMapPackage(MMPK_PATH);
-        mmpk.addDoneLoadingListener(() -> {
-            List<ArcGISMap> maps = mmpk.getMaps();
-            if (0 < maps.size()) {
-                map = maps.get(0);
-                mapView.setMap(map);
+        mmpk.addDoneLoadingListener(new Runnable() {
+            @Override
+            public void run() {
+                List<ArcGISMap> maps = mmpk.getMaps();
+                if (0 < maps.size()) {
+                    map = maps.get(0);
+                    mapView.setMap(map);
+                }
+                map.setBasemap(Basemap.createNationalGeographic());
             }
-            map.setBasemap(Basemap.createNationalGeographic());
         });
         mmpk.loadAsync();
     }


### PR DESCRIPTION
Instant Run doesn't work with Jack, and Java 8 and lambdas don't work without Jack. Instant Run makes development so much faster that it's not worth using Java 8 features like lambdas until they work without Jack (if that's even planned).