### PR TITLE
Updated macOS to Runtime 100.2

### DIFF
--- a/runtime-workshop/exercises/macOS/Swift/Exercise 1 Map and Scene.md
+++ b/runtime-workshop/exercises/macOS/Swift/Exercise 1 Map and Scene.md
@@ -42,7 +42,7 @@ If you need some help, you can refer to [the solution to this exercise](../../..
     use_frameworks!
 
     target 'WorkshopApp' do
-        pod 'ArcGIS-Runtime-SDK-macOS', '100.1'
+        pod 'ArcGIS-Runtime-SDK-macOS', '100.2'
     end
     ```
 

--- a/runtime-workshop/solutions/macOS/Swift/Ex1_MapAndScene/Podfile
+++ b/runtime-workshop/solutions/macOS/Swift/Ex1_MapAndScene/Podfile
@@ -2,5 +2,5 @@ platform :osx, '10.12'
 use_frameworks!
 
 target 'WorkshopApp' do
-    pod 'ArcGIS-Runtime-SDK-macOS', '100.1'
+    pod 'ArcGIS-Runtime-SDK-macOS', '100.2'
 end

--- a/runtime-workshop/solutions/macOS/Swift/Ex1_MapAndScene/WorkshopApp/Info.plist
+++ b/runtime-workshop/solutions/macOS/Swift/Ex1_MapAndScene/WorkshopApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2017.09</string>
+	<string>2018.03</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/runtime-workshop/solutions/macOS/Swift/Ex2_ZoomButtons/Podfile
+++ b/runtime-workshop/solutions/macOS/Swift/Ex2_ZoomButtons/Podfile
@@ -2,5 +2,5 @@ platform :osx, '10.12'
 use_frameworks!
 
 target 'WorkshopApp' do
-    pod 'ArcGIS-Runtime-SDK-macOS', '100.1'
+    pod 'ArcGIS-Runtime-SDK-macOS', '100.2'
 end

--- a/runtime-workshop/solutions/macOS/Swift/Ex2_ZoomButtons/WorkshopApp/Info.plist
+++ b/runtime-workshop/solutions/macOS/Swift/Ex2_ZoomButtons/WorkshopApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2018.03</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/runtime-workshop/solutions/macOS/Swift/Ex3_OperationalLayers/Podfile
+++ b/runtime-workshop/solutions/macOS/Swift/Ex3_OperationalLayers/Podfile
@@ -2,5 +2,5 @@ platform :osx, '10.12'
 use_frameworks!
 
 target 'WorkshopApp' do
-    pod 'ArcGIS-Runtime-SDK-macOS', '100.1'
+    pod 'ArcGIS-Runtime-SDK-macOS', '100.2'
 end

--- a/runtime-workshop/solutions/macOS/Swift/Ex3_OperationalLayers/WorkshopApp/Info.plist
+++ b/runtime-workshop/solutions/macOS/Swift/Ex3_OperationalLayers/WorkshopApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2018.03</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/runtime-workshop/solutions/macOS/Swift/Ex4_BufferAndQuery/Podfile
+++ b/runtime-workshop/solutions/macOS/Swift/Ex4_BufferAndQuery/Podfile
@@ -2,5 +2,5 @@ platform :osx, '10.12'
 use_frameworks!
 
 target 'WorkshopApp' do
-    pod 'ArcGIS-Runtime-SDK-macOS', '100.1'
+    pod 'ArcGIS-Runtime-SDK-macOS', '100.2'
 end

--- a/runtime-workshop/solutions/macOS/Swift/Ex4_BufferAndQuery/WorkshopApp/Info.plist
+++ b/runtime-workshop/solutions/macOS/Swift/Ex4_BufferAndQuery/WorkshopApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2018.03</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/runtime-workshop/solutions/macOS/Swift/Ex5_Routing/Podfile
+++ b/runtime-workshop/solutions/macOS/Swift/Ex5_Routing/Podfile
@@ -2,5 +2,5 @@ platform :osx, '10.12'
 use_frameworks!
 
 target 'WorkshopApp' do
-    pod 'ArcGIS-Runtime-SDK-macOS', '100.1'
+    pod 'ArcGIS-Runtime-SDK-macOS', '100.2'
 end

--- a/runtime-workshop/solutions/macOS/Swift/Ex5_Routing/WorkshopApp/Info.plist
+++ b/runtime-workshop/solutions/macOS/Swift/Ex5_Routing/WorkshopApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2018.03</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
- Updated macOS exercises and solutions to ArcGIS Runtime 100.2.0
- Bumped app version to 2018.03